### PR TITLE
Adding Option to give users finer control of what results get cached.

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,0 +1,27 @@
+package funnel
+
+import "time"
+
+type Option func(*Config)
+
+// WithTimeout defines the maximum time that goroutines will wait for ending of operation (the default is one minute)
+func WithTimeout(t time.Duration) Option {
+	return func(cfg *Config) {
+		cfg.timeout = t
+	}
+}
+
+// WithCacheTtl defines the time for which the result can remain cached (the default is 0 )
+func WithCacheTtl(cTtl time.Duration) Option {
+	return func(cfg *Config) {
+		cfg.cacheTtl = cTtl
+	}
+}
+
+// WithShouldCachePredicate allows more control over which responses should be cached.
+// If this option is used responses from execute will only be cached if the predicate provided returns true.
+func WithShouldCachePredicate(p func(interface{}, error) bool) Option {
+	return func(cfg *Config) {
+		cfg.shouldCache = p
+	}
+}


### PR DESCRIPTION
Background information
Our team is currently using the Funnel to cache network request.
It was noticed that error responses are also cached, which is less then ideal.


Implementation summary
Add an Option to the Funnel constructor that takes in a predicate that will return true if a result 
should be cached and false otherwise. The predicate will have the following signature func(interface{}, error)bool
which matches the return value from the execute.
With this solutions user can chose to have complete control of what results get cached or whether to use the default behavior.

Before & after
Before:
No option to control what gets cached.

After:
func WithShouldCachePredicate(p func(interface{}, error) bool) Option {
	return func(cfg *Config) {
		cfg.shouldCache = p
	}
}

Risk mitigation
Unit test has been added to cover the new Option

Ticket
https://jira.mailchimp.com/browse/DATABRIDGE-1003